### PR TITLE
Strip filename parts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,4 @@ fabric.properties
 # Created by .ignore support plugin (hsz.mobi)
 learn/*
 .idea/*
+token.json

--- a/main.py
+++ b/main.py
@@ -13,7 +13,7 @@ TOKEN_FILENAME = "./token.json"
 
 
 def pathify(course, section, file, root="."):
-    return os.path.join(root, course, section, file)
+    return os.path.join(root, course.strip(), section.strip(), file.strip())
 
 
 def get_saved_token():


### PR DESCRIPTION
Each part of the filename is now stripped to remove trailing spaces. #9 